### PR TITLE
Improve, reframe and fact-check the sailing MOB post

### DIFF
--- a/categories/blog/2020-07-25-sailing-mob.md
+++ b/categories/blog/2020-07-25-sailing-mob.md
@@ -26,15 +26,15 @@ _cover photo credit [unsplash](https://unsplash.com/photos/HvIdCs2aU-k)_
  
 ## Intro
 
-The man overboard maneuver can be one of the most daunting things to get your head around when getting into sailing. Mostly because there’s a few variations around the same theme, and some variables to take into account, eg are you going under sail, or motor etc.. When you first learn about it, generally you get thought one of these technique, and altho mastering one of those it's definitely a valuable skill, having an overview of the other option and under which conditions one might be better then the other could be the factor that makes the split second difference in a successful MOB recovery.
+The man overboard maneuver can be one of the most daunting things to get your head around when you're getting into sailing. That's mostly because there are a few variations on the same theme, with variables to take into account — for example, whether you're under sail or motor. When you first learn about it, you're generally taught one technique, and while mastering that one is definitely a valuable skill, having an overview of the other options — and knowing under which conditions one might work better than another — could be the difference that makes a successful MOB recovery.
 
-In this blog post I am going to break it down, looking at what is considered best practice in both the [RYA](https://www.rya.org.uk/) and [ASA](https://asa.com/) go to books.
+In this blog post I am going to break it down, looking at what is considered best practice in both the [RYA](https://www.rya.org.uk/) and [ASA](https://asa.com/) go-to books.
 
-In 2012 I got my Sailing RYA [Yachtmaster](https://en.wikipedia.org/wiki/Yachtmaster) (Offshore) from [UKSA](https://uksa.org/) qualification, after an intense residential live a board 4 months course ( [see this blog for more on that adventure]({{ site.url }}/sailing-blog-2011-2012) )
+In 2012 I got my RYA [Yachtmaster](https://en.wikipedia.org/wiki/Yachtmaster) (Offshore) qualification from [UKSA](https://uksa.org/), after an intense, live-aboard, four-month residential course ([see this blog post for more on that adventure]({{ site.url }}/sailing-blog-2011-2012)).
 
-In 2014 I Worked for [Med Sailors](https://www.medsailors.com) in Croatia. After that, life got in the way, and a side from the sporadic dinghy sailing while on holiday, Iast year, during the pandemic in 2020 I had a chance to briefly get back into it.
+In 2014 I worked for [Med Sailors](https://www.medsailors.com) in Croatia. After that, life got in the way, and aside from some sporadic dinghy sailing while on holiday, I didn't get back into it until 2020, when the pandemic gave me a chance to briefly pick it up again.
 
-So first things first, I started looking into man overboard maneuvers to brush up on skills and drills.
+So, first things first: I started looking into man overboard maneuvers to brush up on skills and drills.
 
 > “There is no RYA standard method for retrieving a man overboard; you can tack or gybe and use any method you please. A gybe is quick but be careful or you will end up with a second person overboard. You must end up stopped next to the casualty in the water and have thought of a way of getting a real person on board. This is going to be much easier if you make contact early. The longer the boat handling takes, the colder, weaker and more helpless the casualty becomes.”
 >
@@ -46,35 +46,25 @@ So first things first, I started looking into man overboard maneuvers to brush u
 
 ## Terminology
 
-To lower the barrier of entry for this post, here’s a few quick explanation of some of the sailing terminology used.
+To lower the barrier to entry for this post, here are a few quick explanations of some of the sailing terminology used.
 
-### Point of sails
+### Point of sail
 
 ![Point of sails diagram](/img/sailing-mob/rya-Points-of-sail-lrg.jpg)
 
-[Do you know your points of sail?](https://web.archive.org/web/20210430060025/https://www.rya.org.uk/newsevents/e-newsletters/inbrief/Pages/do-you-know-your-points-of-sail.aspx)
+RYA's [Do you know your points of sail?](https://web.archive.org/web/20210430060025/https://www.rya.org.uk/newsevents/e-newsletters/inbrief/Pages/do-you-know-your-points-of-sail.aspx) is a good explainer.
 
-RYA point of sails 
-
-[ASA's Sailing Challenge App - iOS and Android](https://asa.com/sailing-challenge-app/)
-
-ASA game has got a good section about about point of sails.
+The [ASA's Sailing Challenge App (iOS and Android)](https://asa.com/sailing-challenge-app/) also has a good section covering points of sail.
 
 ### Heave to
 
-[https://youtu.be/uQTOfns6OjU?t=66](https://youtu.be/uQTOfns6OjU?t=66)
-
-[How to heave to in a yacht – Skip Novak's Storm Sailing](https://youtu.be/uQTOfns6OjU?t=66)
+On YouTube - [How to heave to in a yacht – Skip Novak's Storm Sailing](https://youtu.be/uQTOfns6OjU?t=66)
 
 [Heaving to - Wikipedia](https://en.wikipedia.org/wiki/Heaving_to)
-
-[Heaving to](https://en.wikipedia.org/wiki/Heaving_to)
 
 ### Tack
 
 [Tacking (sailing) - Wikipedia](https://en.wikipedia.org/wiki/Tacking_(sailing))
-
-[https://en.wikipedia.org/wiki/Tacking_(sailing)](https://en.wikipedia.org/wiki/Tacking_(sailing))
 
 ### Jibe
 
@@ -107,7 +97,7 @@ This is yacht** Puffin, Puffin, Puffin
 
 ### Variables
 
-Some of the variables that might come into play when choosing how to tackle the MOB situation are as follow 
+Some of the variables that might come into play when choosing how to tackle the MOB situation are as follows:
 
 - Sail
     - Both sails
@@ -137,7 +127,7 @@ Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.
     > 
     > - Excerpt From: [The American Sailing Association. “Sailing Made Easy.”](https://books.apple.com/us/book/sailing-made-easy/id1090161781). 
 
-1. **Throw** floating aids
+3. **Throw** floating aids
     1. Lifebelts
     2. Danbuoy
         1. Ideally 
@@ -146,7 +136,7 @@ Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.
             >
             > - Excerpt From: [Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847). 
 
-2. **Call / Mayday** / Radio alert
+4. **Call / Mayday** / Radio alert
     1. MOB button on GPS
     2. Call VHF Channel 16 to alert of the MOB situation
         1. “Pan-Pan, all stations” if not life threatening
@@ -159,7 +149,7 @@ Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.
 
 ## Common key parts of maneuvers
 
-In the section below we’ll see a few different maneuvers, but thought it be useful to highlight some common steps
+In the section below we'll look at a few different maneuvers, but thought it would be useful to first highlight some common steps.
 
 - **Turn your engine on**. If the engine fails, proceed to MOB under sail, otherwise furl in the sails.
 - If under sail can do *optional* **heave to**, to buy time to do “first response” steps described above.
@@ -177,15 +167,15 @@ In the section below we’ll see a few different maneuvers, but thought it be us
     >
     > - Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412). 
 
-### Short handed handed MOB
+### Short-handed MOB
 
-Consider  heaving to, to make time to follow those steps.
+Consider heaving to first, to buy time to follow those steps.
 
 > “If you are shorthanded and you need to do all these actions yourself, heave to by doing a crash tack to stop the boat as near to the MOB as possible ”.
 >
 > - Excerpt From: [Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847) 
 
-## Manovouvers (recovery steps)
+## Maneuvers (recovery steps)
 
 ### MOB under power
 
@@ -233,19 +223,11 @@ From [RYA Man overboard](https://www.rya.org.uk/knowledge-advice/cruising-tips/b
 
 Option with heaving from Royal Yachting Association. [“RYA Yachtmaster Handbook (E-G70).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-yachtmaster-handbook-e-g70/id1361646263) 
 
-[https://youtu.be/jqoSwG0Rfn4](https://youtu.be/jqoSwG0Rfn4)
-
 On YouTube - [Nautilus Sailing - Learn How To Sail: Sailing Basics Video Series - Man Overboard Drill](https://youtu.be/jqoSwG0Rfn4)
 
-From sail to power
+From sail to power - On YouTube - [How to recover a man overboard – Yachting World Bluewater Sailing Series | Yachting World](https://youtu.be/MIn3W66N-3I)
 
-[https://youtu.be/MIn3W66N-3I](https://youtu.be/MIn3W66N-3I)
-
-[How to recover a man overboard – Yachting World Bluewater Sailing Series | Yachting World](https://youtu.be/MIn3W66N-3I)
-
-[https://youtu.be/C1XLaCHEIbU](https://youtu.be/C1XLaCHEIbU)
-
-On YouTube - practical boat owner - [Man Overboard - recovery under engine](https://youtu.be/C1XLaCHEIbU)
+On YouTube - Practical Boat Owner - [Man Overboard - recovery under engine](https://youtu.be/C1XLaCHEIbU)
 
 ### Figure of Eight
 
@@ -261,7 +243,11 @@ On YouTube - practical boat owner - [Man Overboard - recovery under engine](http
 - Go onto a broad reach
 - Then onto a close reach
 - 1 knot speed
-- Approach COB “Aim to stop the boat upwind of the MOB so that it will drift down towards them”Excerpt From: Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018. [https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847)
+- Approach COB
+
+    > “Aim to stop the boat upwind of the MOB so that it will drift down towards them.”
+    >
+    > - Excerpt From: [Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847)
 
 > “Sail to a point from where you can head up onto a close reach aiming just slightly to windward of the COB”
 >
@@ -269,15 +255,9 @@ On YouTube - practical boat owner - [Man Overboard - recovery under engine](http
 
 ![Figure of 8 diagram](/img/sailing-mob/asa-103-all-3-days-2018-29-638.jpg)
 
-[https://youtu.be/fF8CQHUfafI?t=285](https://youtu.be/fF8CQHUfafI?t=285)
-
 On YouTube - Florb/Dylan Magaster - [How I Learned to operate a Sailing Boat in 5 Days - 4.45min](https://youtu.be/fF8CQHUfafI?t=285) to 6.39min
 
-Example on a dinghy
-
-[https://youtu.be/LGZrK3tVCFk](https://youtu.be/LGZrK3tVCFk)
-
-On YouTube - Royal Yachting Association - RYA - [Man over board - with Olympic Medalist, Shirley Robertson](https://youtu.be/LGZrK3tVCFk)
+Example on a dinghy - On YouTube - Royal Yachting Association - [Man over board - with Olympic Medalist, Shirley Robertson](https://youtu.be/LGZrK3tVCFk)
 
 ### Broad Reach Close Reach (BRCR) - (Reach Tack Reach)
 
@@ -289,45 +269,41 @@ On YouTube - Royal Yachting Association - RYA - [Man over board - with Olympic M
 
 > “One advantage of this maneuver is that, after the tack, the boat is heading almost directly toward the MOB”
 >
->- Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412) 
+> - Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412) 
 
 ![Broad Reach close reach diagram](/img/sailing-mob/asa-103-all-3-days-2018-31-638-1.jpg)
 
 <!-- [https://www.slideshare.net/CaptEdHerlihy/asa-103-all-3-days-2018](https://www.slideshare.net/CaptEdHerlihy/asa-103-all-3-days-2018) -->
 
-[https://youtu.be/xlexzR3yPKA](https://youtu.be/xlexzR3yPKA)
-
-On YouTube - Practical boat owner-  [Man Overboard under sail - Reach Tack Reach method](https://youtu.be/xlexzR3yPKA)
+On YouTube - Practical Boat Owner - [Man Overboard under sail - Reach Tack Reach method](https://youtu.be/xlexzR3yPKA)
 
 ### Quick Stop with jibe
 
-Downside - Jibe
+Downside - Jibe.
 
 > “it should only be used by a well-practiced crew and in light to moderate winds.”
 >
->- Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+> - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
 
 - Head to wind
 - Jibe
 - Circle back to COB
-- If time furl the jib otherwise let it luf
-- Luf the main sail to stop the boat
+- If time furl the jib otherwise let it luff
+- Luff the main sail to stop the boat
 
 ![Quick Stop Diagram](/img/sailing-mob/asa-103-all-3-days-2018-30-638.jpg)
 
 ![Diagram](/img/sailing-mob/diagram.png)
 
-https://youtu.be/yuxCH_6tXko
-
-On YouTube - Practical boat owner -  [Man Overboard under sail - the Quick Stop method](https://youtu.be/yuxCH_6tXko)
+On YouTube - Practical Boat Owner - [Man Overboard under sail - the Quick Stop method](https://youtu.be/yuxCH_6tXko)
 
 ### The Life-sling
 
-Also good for shorthanded
+Also good for short-handed crews.
 
-Careful not to get line in the propeller.
+Careful not to get the line in the propeller.
 
-Another thing to be mindful with the life-sling option is that you need to be confident enough that your COB is able to grab the line. Eg they are not in shock or otherwise incapacitated that they wouldn't be able to grab and hold onto the line when it reaches them.
+Another thing to be mindful of with the life-sling option is that you need to be confident enough that your COB is able to grab the line — e.g. that they're not in shock or otherwise incapacitated in a way that would stop them grabbing and holding onto the line when it reaches them.
 
 > “The goal is to drag the LifeSling so its line passes over the MOB”
 >
@@ -357,13 +333,9 @@ Once the sling is thrown, the boat is sailed round to encircle the casualty. Wit
 
 ![short handed life sling diagram](/img/sailing-mob/short-handed-life-sling.png)
 
-[https://youtu.be/bG8KwodxjiE](https://youtu.be/bG8KwodxjiE)
+On YouTube - Sailing SV Delos - [Man Overboard Drill](https://youtu.be/bG8KwodxjiE). Although it's recommended not to use an actual crew member for the drill.
 
-On YouTube - Sailing SV Delos- Man Overboard Drill. Altho it is reccomended to not use an actual crew member to do the drill. 
-
-[https://youtu.be/IfszopvJ2-Y](https://youtu.be/IfszopvJ2-Y)
-
-On YouTube - Practical boat owner - [Man Overboard - using a lifesling](https://youtu.be/IfszopvJ2-Y)
+On YouTube - Practical Boat Owner - [Man Overboard - using a lifesling](https://youtu.be/IfszopvJ2-Y)
 
 ## COB back onto the boat
 
@@ -373,29 +345,26 @@ On YouTube - Practical boat owner - [Man Overboard - using a lifesling](https://
 
 ## Solo MOB
 
-[https://youtu.be/4gQbDzXAOdY](https://youtu.be/4gQbDzXAOdY)
-
 On YouTube - Bradley Enterline - [Solo Man Overboard Drill](https://youtu.be/4gQbDzXAOdY)
 
 ## Williamson turn
 
-Good if you lose sight, or low visibility
+Good if you lose sight of the MOB, or in low visibility.
 
 - Note the course and position
-- add 60 degrees to your compass heading
-- Then when reached do 180
+- Add 60 degrees to your compass heading
+- Then, when reached, do a 180
 
 > “The Williamson turn is a maneuver used to bring a ship or boat under power back to a point it previously passed through, often for the purpose of recovering a man overboard. It was named for John Williamson, USNR, who used it in 1943 to recover a man who had fallen overboard.”
-
->1. Put the rudder over full.
->2. If in response to a man overboard, put the rudder toward the person (e.g., if the person fell over the starboard side, put the rudder over starboard full).
->3. Shift the rudder full to the opposite side to stop vessel 60 degrees from its original course and start turning to the opposite direction.
->4. When heading about 20 degrees short of the reciprocal, put the rudder amidships so that vessel turns onto the reciprocal course.
->5. Bring the vessel upwind of the person, stop the vessel in the water with the person alongside, well forward of the propellers
->6. If dealing with a man overboard, always bring the vessel upwind of the person. Stop the vessel in the water with the person well forward of the propellers.”
-
-[Man overboard rescue turn - Wikipedia](https://en.wikipedia.org/wiki/Man_overboard_rescue_turn#Williamson_turn)
-
+>
+> 1. Put the rudder over full.
+> 2. If in response to a man overboard, put the rudder toward the person (e.g., if the person fell over the starboard side, put the rudder over starboard full).
+> 3. Shift the rudder full to the opposite side to stop the vessel 60 degrees from its original course and start turning in the opposite direction.
+> 4. When heading about 20 degrees short of the reciprocal, put the rudder amidships so the vessel turns onto the reciprocal course.
+> 5. Bring the vessel upwind of the person, and stop it in the water with the person alongside, well forward of the propellers.
+> 6. If dealing with a man overboard, always bring the vessel upwind of the person, and stop it in the water with the person well forward of the propellers.
+>
+> - [“Man overboard rescue turn.” Wikipedia.](https://en.wikipedia.org/wiki/Man_overboard_rescue_turn#Williamson_turn)
 
 [https://youtu.be/hXyY0BcaxbU](https://youtu.be/hXyY0BcaxbU)
 
@@ -431,7 +400,7 @@ Maneuver the boat to windward of the MOB so someone standing forward of the beam
 >
 > - [Royal Yachting Association. “RYA Yachtmaster Handbook (E-G70).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-yachtmaster-handbook-e-g70/id1361646263) 
 
-Recovering unconscious or weak(eg because of hypothermia) COB, that might need extra help getting back onto the boat.
+Recovering an unconscious or weak (e.g. due to hypothermia) COB, who might need extra help getting back onto the boat.
 
 > “It is essential not to lose contact once alongside, so a line needs to be attached either round the chest of the person in the water or better still to the harness or life jacket. Achieving this with a weak or unconscious casualty means another crew member attaching themselves to the boat and getting down to water level. Launching the dinghy or possibly the liferaft might be the only way.”
 >
@@ -453,7 +422,7 @@ Stop the boat asap
 <!-- ##  Man overboard liquid color  -->
 
 
-## References and furthers readings
+## References and further reading
 
 - Royal Yachting Association. “**RYA Competent Crew Skills** (E-CCPCN).” Royal Yachting Association, 2018. 
 - [Royal Yachting Association. “**RYA Day Skipper Handbook Sail** (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847)
@@ -462,43 +431,24 @@ Stop the boat asap
 - [The American Sailing Association. “**Coastal Cruising Made Easy**.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695)
 - [The American Sailing Association. “**Bareboat Cruising Made Easy**.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412)
 - [The American Sailing Association. “**Cruising Catamarans Made Easy**.”](https://books.apple.com/us/book/cruising-catamarans-made-easy/id1129553426)
-- [Man overboard](https://web.archive.org/web/20210420025701/https://www.rya.org.uk/knowledge-advice/cruising-tips/boat-handling-sail/Pages/man-overboard.aspx)
-- [RYA - Man overboard](https://www.rya.org.uk/knowledge-advice/cruising-tips/boat-handling-sail/Pages/man-overboard.aspx)
+- [RYA - Man overboard](https://www.rya.org.uk/knowledge-advice/cruising-tips/boat-handling-sail/Pages/man-overboard.aspx) ([archived version](https://web.archive.org/web/20210420025701/https://www.rya.org.uk/knowledge-advice/cruising-tips/boat-handling-sail/Pages/man-overboard.aspx))
 - [Force 6 man overboard recovery - Practical Boat Owner](https://www.pbo.co.uk/seamanship/force-6-man-overboard-recovery-43967)
-- [Force 6 man overboard recovery](https://www.pbo.co.uk/seamanship/force-6-man-overboard-recovery-43967)
 - [Is it safe to use a tether?](https://www.pbo.co.uk/seamanship/is-it-safe-to-use-a-tether-25125)
-- 
+
 ## Other Videos of MOB
 
-[https://youtu.be/8NpzMnwR6VA?t=180](https://youtu.be/8NpzMnwR6VA?t=180)
+On YouTube - The Sailing Frenchman - [Man Overboard offshore: prepare for the worst, hope for the best - Ep110 - The Sailing Frenchman - 2:59](https://youtu.be/8NpzMnwR6VA?t=179) as part of Clipper's crew training.
 
-On YouTube - The Sailing Frenchman - [Man Overboard offshore: prepare for the worst, hope for the best - Ep110 - The Sailing Frenchman - 2:59](https://youtu.be/8NpzMnwR6VA?t=179) as part of clipper's crew training.
-
-
-https://youtu.be/VPmNo-jo4tg      
-
-On Youtube - [Derry~Londonderry~Doire successfully recovers man overboard during Clipper Race](https://youtu.be/VPmNo-jo4tg)
-
-https://youtu.be/8Ge5tuP8x1k         
+On YouTube - [Derry~Londonderry~Doire successfully recovers man overboard during Clipper Race](https://youtu.be/VPmNo-jo4tg)
 
 On YouTube - [Andrew Taylor Rescue Story](https://youtu.be/8Ge5tuP8x1k)
 
-[https://youtu.be/RNxcjWCSKpY](https://youtu.be/RNxcjWCSKpY)
-
 On YouTube - [Miracle Rescue: Man Overboard During Storm Survives](https://youtu.be/RNxcjWCSKpY)
 
-[https://youtu.be/0duIqxqGUbk](https://youtu.be/0duIqxqGUbk)
+On YouTube - [SAIL SMARTS SKILLS - MAN OVERBOARD - SAIL FROM HOME KIDS LEARNING - SEAMANSHIP](https://youtu.be/0duIqxqGUbk)
 
-[SAIL SMARTS SKILLS - MAN OVERBOARD - SAIL FROM HOME KIDS LEARNING - SEAMANSHIP](https://youtu.be/0duIqxqGUbk)
+On YouTube - [Dramatic Footage of Man Overboard | Volvo Ocean Race](https://youtu.be/RqlVm5eb9PI)
 
+[https://youtu.be/R9TxerbH4Ek](https://youtu.be/R9TxerbH4Ek)
 
-https://youtu.be/RqlVm5eb9PI         
-
-[Dramatic Footage of Man Overboard | Volvo Ocean Race](https://youtu.be/RqlVm5eb9PI)
-
-
-
-https://youtu.be/R9TxerbH4Ek
-
-[Morning Light](https://youtu.be/xliuVqWKq5w)
-Disney documentary morning light has got a man over board scene as part of the crew's training.
+On YouTube - [Morning Light](https://youtu.be/xliuVqWKq5w) - Disney documentary that includes a man overboard scene as part of the crew's training.

--- a/categories/blog/2020-07-25-sailing-mob.md
+++ b/categories/blog/2020-07-25-sailing-mob.md
@@ -36,13 +36,21 @@ In 2014 I worked for [Med Sailors](https://www.medsailors.com) in Croatia. After
 
 So, first things first: I started looking into man overboard maneuvers to brush up on skills and drills.
 
+The first thing that struck me is that neither body actually prescribes a single "correct" maneuver. The RYA is explicit that the method is up to you, and defines success by the outcome instead:
+
 > “There is no RYA standard method for retrieving a man overboard; you can tack or gybe and use any method you please. A gybe is quick but be careful or you will end up with a second person overboard. You must end up stopped next to the casualty in the water and have thought of a way of getting a real person on board. This is going to be much easier if you make contact early. The longer the boat handling takes, the colder, weaker and more helpless the casualty becomes.”
 >
 > - Royal Yachting Association. [“RYA Yachtmaster Handbook (E-G70).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-yachtmaster-handbook-e-g70/id1361646263). 
 
+That last sentence is the one worth sitting with: the clock isn't just about the boat, it's about the person in the water getting progressively less able to help with their own rescue. Which reframes "which maneuver is best" into "which maneuver gets *this* boat, with *this* crew, alongside fastest."
+
+The ASA arrives at the same place from the other direction, by listing what the choice actually depends on:
+
 > “The goal of any MOB maneuver is to bring the boat to the MOB as quickly as possible. How that is accomplished will depend on many factors, including the point of sail the boat was on, the wind and sea conditions, and the skill and experience of the skipper and crew”
 >
 > - Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412) 
+
+Between them, those two quotes set up the rest of this post. The maneuvers below aren't a ranked list where one wins — they're options you pick between based on your point of sail, the conditions, and how many competent hands you have. That's exactly why learning only one of them leaves a gap.
 
 ## Terminology
 
@@ -50,13 +58,17 @@ To lower the barrier to entry for this post, here are a few quick explanations o
 
 ### Point of sail
 
+Your point of sail is your angle to the wind, and it's the vocabulary every maneuver below is written in — "go onto a beam reach", "return on a close reach". So it's worth being comfortable with the diagram before the maneuvers will read as anything other than jargon.
+
 ![Point of sails diagram](/img/sailing-mob/rya-Points-of-sail-lrg.jpg)
 
 RYA's [Do you know your points of sail?](https://web.archive.org/web/20210430060025/https://www.rya.org.uk/newsevents/e-newsletters/inbrief/Pages/do-you-know-your-points-of-sail.aspx) is a good explainer.
 
-The [ASA's Sailing Challenge App (iOS and Android)](https://asa.com/sailing-challenge-app/) also has a good section covering points of sail.
+The [ASA's Sailing Challenge App (iOS and Android)](https://asa.com/sailing-challenge-app/) also has a good section covering points of sail. Being a game, it's a surprisingly effective way to drill this until it's automatic — which matters, because in a real MOB you don't want to be working out your angle to the wind from first principles.
 
 ### Heave to
+
+Heaving to is effectively the pause button: you back the headsail against the mainsail so the boat sits more or less stationary without anyone steering. It comes up repeatedly below as the *optional* first move, because it's what buys you the time to do everything else — throw flotation, make the radio call, get the engine on — without the boat sailing further away from the person in the water.
 
 On YouTube - [How to heave to in a yacht – Skip Novak's Storm Sailing](https://youtu.be/uQTOfns6OjU?t=66)
 
@@ -64,15 +76,19 @@ On YouTube - [How to heave to in a yacht – Skip Novak's Storm Sailing](https:/
 
 ### Tack
 
+Tacking is turning the bow *through* the wind to change direction.
+
 [Tacking (sailing) - Wikipedia](https://en.wikipedia.org/wiki/Tacking_(sailing))
 
 ### Jibe
+
+Jibing is the opposite: turning the stern through the wind. It's the faster way round, but the boom crosses the boat under load — which is exactly the risk the RYA flagged in the intro about ending up with a second person overboard. That trade-off is the whole story of the Quick Stop maneuver further down.
 
 [Jibe - Wikipedia](https://en.wikipedia.org/wiki/Jibe)
 
 ### Mayday
 
-A call done over the radio to ask for help.
+A call done over the radio to ask for help. Worth having the structure in your head rather than improvising it — the format below exists so that whoever is listening gets the information they need in a predictable order.
 
 Example from Mayday message
 
@@ -97,7 +113,7 @@ This is yacht** Puffin, Puffin, Puffin
 
 ### Variables
 
-Some of the variables that might come into play when choosing how to tackle the MOB situation are as follows:
+Given the ASA quote above — that the right maneuver "will depend on many factors" — it's worth making those factors explicit. Some of the variables that might come into play when choosing how to tackle the MOB situation are as follows:
 
 - Sail
     - Both sails
@@ -114,11 +130,17 @@ Other
 - Number of crew
 - Experience of crew
 
+The last two are easy to overlook when reading a diagram, but they're often what actually decides things: a maneuver that assumes someone can furl the jib while someone else spots and someone else steers simply isn't available to a couple sailing double-handed.
+
 ## “Pre maneuver” (first response)
+
+Before any of the maneuvers, there's a set of things that happen immediately, regardless of which one you then choose. The ASA packages them as a mnemonic:
 
 **“Y, P**, **T**, **S**, **C**”
 
 Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412). 
+
+The point of a mnemonic here is that this is the part you don't want to be improvising. These steps mostly cost seconds and buy you enormous amounts — a spotter keeping eyes on, flotation in the water, and someone else alerted — before the boat handling even starts.
 
 1. **Yell/Shout** “Man overboard”
 2. **Point** Nominate a spotter / pointer
@@ -126,6 +148,8 @@ Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.
     > “Throughout the maneuver that follows, the spotter never takes his eyes off the COB, points toward him at all times, and communicates regularly with the helmsman, describing the COB’s location relative to the boat using both distance (e.g., “Three boat lengths”) and direction (e.g., “Dead astern”).”
     > 
     > - Excerpt From: [The American Sailing Association. “Sailing Made Easy.”](https://books.apple.com/us/book/sailing-made-easy/id1090161781). 
+
+    Note that this is a dedicated job for one person, who does nothing else for the whole maneuver. A head in the water is astonishingly hard to spot even in moderate seas, and once lost it's very hard to reacquire — hence the "never takes his eyes off" framing, and hence the Williamson turn further down existing specifically for the case where sight *has* been lost.
 
 3. **Throw** floating aids
     1. Lifebelts
@@ -135,6 +159,8 @@ Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.
             > “Have a drogue, a small sea anchor, attached to each belt to reduce this drift”
             >
             > - Excerpt From: [Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847). 
+
+        The reasoning is that flotation blows downwind faster than a person floating low in the water does. Without a drogue, the thing you threw to mark the spot quietly stops marking the spot.
 
 4. **Call / Mayday** / Radio alert
     1. MOB button on GPS
@@ -149,7 +175,7 @@ Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.
 
 ## Common key parts of maneuvers
 
-In the section below we'll look at a few different maneuvers, but thought it would be useful to first highlight some common steps.
+In the section below we'll look at a few different maneuvers, but thought it would be useful to first highlight some common steps. Once you line the maneuvers up side by side, most of what looks like variation turns out to be different routes to the same final approach.
 
 - **Turn your engine on**. If the engine fails, proceed to MOB under sail, otherwise furl in the sails.
 - If under sail can do *optional* **heave to**, to buy time to do “first response” steps described above.
@@ -167,7 +193,11 @@ In the section below we'll look at a few different maneuvers, but thought it wou
     >
     > - Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412). 
 
+Those three quotes are all circling the same idea, and it's probably the single most useful thing to take from this post: **finish upwind of the person, on a close reach.** The close reach matters because it's the point of sail where you can control your speed with the sails alone — bleed speed by luffing, pick it back up by sheeting in — without having to tack or jibe again at the critical moment. Ending up upwind matters because if you misjudge it, the error is self-correcting: you drift *towards* them. Get it the wrong way round and every second of drift takes you further away, and you have to go round again.
+
 ### Short-handed MOB
+
+The fewer hands you have, the more the "first response" list competes with actually sailing the boat. Heaving to is what resolves that conflict — it takes the boat out of the equation so one person can do several jobs in sequence rather than trying to do them at once.
 
 Consider heaving to first, to buy time to follow those steps.
 
@@ -177,7 +207,11 @@ Consider heaving to first, to buy time to follow those steps.
 
 ## Maneuvers (recovery steps)
 
+With the common pattern established, here are the individual maneuvers. Roughly, they differ in how they get you from wherever you were to that final close-reach approach — and each one trades off speed against risk and against how many crew it needs.
+
 ### MOB under power
+
+The engine removes the constraint of the wind entirely, which makes this the most direct option when it's available. The trade-off is that you've introduced a spinning propeller into the water near the person you're trying to rescue, and most of the guidance below is about managing exactly that.
 
 - Turn on the engine
     - If it doesn’t. Then start one of the other under sail maneuvers
@@ -198,22 +232,34 @@ Consider heaving to first, to buy time to follow those steps.
 - Set to neutral when reach COB
 - Keep COB and sheets away from prop
 
+The sequencing here is the thing to internalise — sails down *before* the engine goes on, and one specific check in between:
+
 > “Your first action, after Y, T, P, S, C, would be to head up into the wind to slow the boat, then furl the jib and, depending on the conditions, the mainsail.
 Before starting the engine, make sure no lines are trailing in the water.”
 >
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
 
+That check for trailing lines isn't a formality. A rope round the propeller turns your engine — the thing that was making this the easy option — into dead weight, and now you're doing an unplanned under-sail recovery having already dropped your sails.
+
+There's also a less obvious reason to get the jib away, which comes from people who've actually been in the water for drills:
+
 > “Volunteer “victims” taking part in organized man-overboard exercises report that flailing jibsheets can be a hazard when the boat is to windward. For this reason the jib should be furled before the boat makes contact with the MOB - if you have crew available to do it”
 >
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695). 
+
+The mainsail is a judgement call rather than a rule, and it cuts both ways:
 
 > “The mainsail might steady the boat in rough seas, but you’ll have to drop it if the boat sails too fast. Some boats might lie hove-to quietly and require little attention while the crew recovers the MOB from the water”
 >
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
 
+Finally, the approach itself. Note that even under power the target is still that same close-reach course, and note how deliberately slow the last few boat lengths are meant to be:
+
 > “MOB under power: As when under sail, the goal is to approach the MOB on a course as if on a close reach. A modern sailboat motoring with any speed will turn sharply when the helm is put hard over — a person standing can be thrown off his feet — so warn the crew and back off the throttle before turning. Stop the boat well before reaching the MOB and inch it toward him with short bursts in forward gear. Engage neutral for the recovery. Make sure no lines are in the water to snag the propellr”
 >
 > - Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412). 
+
+"Short bursts in forward gear", then neutral, is the pattern worth remembering: you want the propeller stopped well before anyone is close enough to touch the boat.
 
 ![MOB recovery under power diagram](/img/sailing-mob/man-overboard-1.jpg)
 
@@ -231,6 +277,8 @@ On YouTube - Practical Boat Owner - [Man Overboard - recovery under engine](http
 
 ### Figure of Eight
 
+This is the one most people are taught first, and it's the most forgiving: everything is done with tacks, so the boom never crosses under load. The cost is that it's the longest way round, since you sail away from the COB before turning back.
+
 - Regardless of your point of sail go onto a beam reach
 - Furl the Genoa
 - Proceed to 3 to 6 boat length spending on wind speed and waves.
@@ -238,6 +286,8 @@ On YouTube - Practical Boat Owner - [Man Overboard - recovery under engine](http
     > “A distance of four to six boat lengths (20 to 30 seconds) should be sufficient — the distance will be shorter in lighter winds and longer in higher winds. ”
     >
     > - [Excerpt From: The American Sailing Association. “Sailing Made Easy.](https://books.apple.com/us/book/sailing-made-easy/id1090161781)” 
+
+    Counterintuitively, you need *more* room in stronger winds, not less — you're buying yourself space to complete the turn and settle onto the approach. Going too early is what leaves you overshooting or arriving too fast.
 
 - Tack into the wind
 - Go onto a broad reach
@@ -261,6 +311,8 @@ Example on a dinghy - On YouTube - Royal Yachting Association - [Man over board 
 
 ### Broad Reach Close Reach (BRCR) - (Reach Tack Reach)
 
+Think of this as the Figure of Eight tightened up. It's still tack-based and so still avoids the jibe, but it uses a single turn rather than a loop, which gets you back sooner and keeps the geometry simpler to judge.
+
 - Optional heave to
 - Broad reach 3 to 4 boat length (15 to 20 sec)
 - Sail onto a run (with wind behind) for a bit to position for the tack and close reach to be a good angle with the COB (Crew over board)
@@ -271,6 +323,8 @@ Example on a dinghy - On YouTube - Royal Yachting Association - [Man over board 
 >
 > - Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412) 
 
+That's a bigger deal than it sounds under stress. Coming out of the tack already pointed at the person means less to work out in the moment and less opportunity to lose sight of them mid-maneuver — which is why this tends to be the one recommended once you're past the basics.
+
 ![Broad Reach close reach diagram](/img/sailing-mob/asa-103-all-3-days-2018-31-638-1.jpg)
 
 <!-- [https://www.slideshare.net/CaptEdHerlihy/asa-103-all-3-days-2018](https://www.slideshare.net/CaptEdHerlihy/asa-103-all-3-days-2018) -->
@@ -279,11 +333,15 @@ On YouTube - Practical Boat Owner - [Man Overboard under sail - Reach Tack Reach
 
 ### Quick Stop with jibe
 
+This is the fastest of the three, because it keeps the boat close to the COB the whole time rather than sailing away and coming back. The catch is in the name of the turn it uses.
+
 Downside - Jibe.
 
 > “it should only be used by a well-practiced crew and in light to moderate winds.”
 >
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+
+Two conditions, both of which have to hold. This is the clearest example in the whole post of why knowing several maneuvers matters: the quickest option is also the one that's off the table in exactly the rough, windy conditions where someone is most likely to have gone over in the first place.
 
 - Head to wind
 - Jibe
@@ -299,37 +357,51 @@ On YouTube - Practical Boat Owner - [Man Overboard under sail - the Quick Stop m
 
 ### The Life-sling
 
-Also good for short-handed crews.
-
-Careful not to get the line in the propeller.
-
-Another thing to be mindful of with the life-sling option is that you need to be confident enough that your COB is able to grab the line — e.g. that they're not in shock or otherwise incapacitated in a way that would stop them grabbing and holding onto the line when it reaches them.
+The life-sling changes the problem you're solving. Every maneuver above ends with the difficult task of stopping the boat in exactly the right spot; this one replaces that with towing a floating line in a circle around the person until it reaches them.
 
 > “The goal is to drag the LifeSling so its line passes over the MOB”
 >
 > - Excerpt From: The American Sailing Association. “Coastal Cruising Made Easy.” https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695
 
-> “if the MOB is able to grasp the line, luff up, stop the boat, and douse the sails. If not, make another circuit.
-Haul the MOB toward the boat and prepare for the recovery stage”
->
-> - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+The RYA describes the same technique, and is useful for what happens *after* contact is made — the sling doubles as the thing you hoist them out of the water with:
 
 > “Other options to consider are a life sling and a throw bag, both of which can be repacked after practice drills. The life sling is rather like a soft lifebelt on a long rope, which is attached to the boat.
 Once the sling is thrown, the boat is sailed round to encircle the casualty. With the sling under their arms the casualty can be pulled to the boat and winched back on board using a halyard. ”
 > 
 > - Excerpt From: [Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847) 
 
+The ASA spells out the payoff, and one important thing the sling is *not*:
+
 > “The LifeSling does not replace the flotation you throw in response to the MOB alarm because it’s tied to the boat and you will tow it away from the MOB. Instead, you deploy it as you make your return toward the MOB, then maneuver the boat around the MOB in an elliptical course to bring the floating line within his grasp. Using the LifeSling eliminates the need to stop the boat precisely at the MOB, which is difficult to do at any time”
 > 
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+
+"Eliminates the need to stop the boat precisely" is the whole appeal — and it's why this is worth knowing for short-handed sailing in particular, where precise boat handling and everything else are competing for the same one or two pairs of hands. But note the first clause: it's tied to the boat, so it gets towed away. It's an addition to the flotation you throw immediately, not a substitute for it.
+
+It also has a real precondition, and it's worth being honest about it. The whole technique depends on the person in the water actively grabbing and holding a line:
+
+> “if the MOB is able to grasp the line, luff up, stop the boat, and douse the sails. If not, make another circuit.
+Haul the MOB toward the boat and prepare for the recovery stage”
+>
+> - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+
+"If not, make another circuit" is doing a lot of work in that sentence. If your COB is in shock, injured, hypothermic or unconscious, they may never be able to take the line — and repeated circuits are burning exactly the time the RYA warned about in the intro. So this is a technique to reach for when you have reason to believe they can help themselves, not a universal answer.
+
+Two practical notes. First, how you pack it determines whether it works at all:
 
 > “Flake, don’t coil, the floating line into the container to ensure it will deploy properly — and make sure it’s secured to the boa”
 > 
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
 
+Coiled line tends to tangle as it pays out; flaked line runs free. This is the kind of detail that's invisible until the one moment it matters, which is a good argument for unpacking and repacking it yourself rather than trusting how it came.
+
+Second, and worth knowing before you decide you can't use this method — and also, careful not to get the line in the propeller:
+
 > “If you don’t have a LifeSling, you can MacGyver a towable device by tying a length of floating line to a float cushion or a horseshoe buoy.”
 >
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+
+So the technique is available on most boats even without the purpose-built kit — what matters is having thought about it in advance, and having *floating* line to hand.
 
 ![short handed life sling diagram](/img/sailing-mob/short-handed-life-sling.png)
 
@@ -339,15 +411,23 @@ On YouTube - Practical Boat Owner - [Man Overboard - using a lifesling](https://
 
 ## COB back onto the boat
 
+Reaching the person is only half the job, and it's easy to treat the maneuver as the finish line. Note the order in the quote below — attached first, lifted second:
+
 > “Get the casualty attached to the boat as soon as possible and get them back onboard using the stern ladder in calm conditions or a halyard winch.”
 >
 > - Excerpt From: [Royal Yachting Association. “RYA Day Skipper Handbook Sail (E-G71).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-day-skipper-handbook-sail-e-g71/id1385607847) 
 
+Getting them attached first means that even if the lift goes wrong, or the boat drifts, you haven't lost them again and had to start over. And the two options given — ladder versus halyard winch — are a reminder that a tired or heavy person in wet clothing is often simply not climbable out by hand, so it's worth knowing in advance where your halyard winch is and how you'd rig it.
+
 ## Solo MOB
+
+Sailing alone removes the assumption underneath all of the above: that someone is left on board to spot, steer and recover. Mostly this shifts the emphasis to prevention — staying clipped on — but the drill is still worth seeing.
 
 On YouTube - Bradley Enterline - [Solo Man Overboard Drill](https://youtu.be/4gQbDzXAOdY)
 
 ## Williamson turn
+
+This one solves a different problem from all the maneuvers above. Those assume you can see the person; this is what you do when you can't — which is also when the spotter's job described earlier has already broken down.
 
 Good if you lose sight of the MOB, or in low visibility.
 
@@ -366,24 +446,34 @@ Good if you lose sight of the MOB, or in low visibility.
 >
 > - [“Man overboard rescue turn.” Wikipedia.](https://en.wikipedia.org/wiki/Man_overboard_rescue_turn#Williamson_turn)
 
+The elegance of it is that it puts you back on your exact reciprocal track — you retrace your own path rather than guessing at a position. Which is why it's a ship-handling technique originally: it works when the thing you're looking for is somewhere behind you and you can no longer see it.
+
 [https://youtu.be/hXyY0BcaxbU](https://youtu.be/hXyY0BcaxbU)
 
 
 ## Catamaran
 
+Everything above assumes a monohull. A catamaran isn't just a bigger version of the same problem — it handles differently in ways that directly affect which maneuver works.
+
 > “The sailing and handling characteristics of a catamaran affect the way you maneuver to recover a man overboard (MOB), whether under sail, under power, or using a combination of both”
 >
 > - Excerpt From: [The American Sailing Association. “Cruising Catamarans Made Easy.”](https://books.apple.com/us/book/cruising-catamarans-made-easy/id1129553426) 
 
+Concretely, the Broad-Reach Close-Reach maneuver still applies, but with the angles adjusted and the engines treated as part of the technique rather than a fallback:
+
 > “The Broad-Reach Close-Reach return maneuver works quite well with a catamaran, but allow for the catamaran’s leeway. Return to the MOB by sailing more on a beam reach than a close reach. Try to put the MOB on the same side as the helm station (note the alternatives shown). Time is of the essence: Don’t hesitate to use the engines to help you through the tack”
+>
+> - Excerpt From: [The American Sailing Association. “Cruising Catamarans Made Easy.”](https://books.apple.com/us/book/cruising-catamarans-made-easy/id1129553426) 
 
 ![Catamara MOB Diagram](/img/sailing-mob/catamara-mob.png)
 
-> - Excerpt From: [The American Sailing Association. “Cruising Catamarans Made Easy.”](https://books.apple.com/us/book/cruising-catamarans-made-easy/id1129553426) 
+The reason for that engine advice is the tacking problem:
 
 > “A catamaran does not turn as sharply, and is markedly slower and more difficult to tack. If the maneuver that offers the most direct return involves tacking, you may need assistance from the engines”
 >
 > - Excerpt From: [The American Sailing Association. “Cruising Catamarans Made Easy.”](https://books.apple.com/us/book/cruising-catamarans-made-easy/id1129553426). 
+
+A catamaran that stalls halfway through a tack has turned a quick recovery into a slow one. Two engines then become a genuine advantage over a monohull — but only if the propeller discipline is right, and having two of them makes that more complicated, not less:
 
 > “You can use one engine to help hold the boat in place, but make absolutely sure to shut downthe engine on the MOB side so a spinning propeller does not become an issue.”
 > 
@@ -394,11 +484,17 @@ Maneuver the boat to windward of the MOB so someone standing forward of the beam
 >
 > - Excerpt From: [The American Sailing Association. “Cruising Catamarans Made Easy.”](https://books.apple.com/us/book/cruising-catamarans-made-easy/id1129553426) 
 
+The pattern across both quotes: engines to neutral immediately, engines back on to manoeuvre once they're clear, then the engine nearest them off before contact.
+
 ## Picking up COB
+
+Having got the boat there, which side you take them on is a decision in its own right, and the consensus is fairly clear:
 
 > “The majority of skippers pick-up the MOB on the leeward side. The rail is lower and the boat is drifting towards rather than away from the casualty. Also, a boat slowing down for a windward pick-up will make leeway and steer its bow across the casualty, which is pretty unnerving for the person in the water.”
 >
 > - [Royal Yachting Association. “RYA Yachtmaster Handbook (E-G70).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-yachtmaster-handbook-e-g70/id1361646263) 
+
+Three separate reasons stacked in one paragraph — lower freeboard to lift over, drift working for you rather than against you, and not swinging the bow across someone who is already having a bad day. Note that this is about the last few metres, and sits alongside the earlier advice to *approach* from upwind: you stop to windward, then take them on the sheltered side as the boat drifts down.
 
 Recovering an unconscious or weak (e.g. due to hypothermia) COB, who might need extra help getting back onto the boat.
 
@@ -406,18 +502,28 @@ Recovering an unconscious or weak (e.g. due to hypothermia) COB, who might need 
 >
 > - [Royal Yachting Association. “RYA Yachtmaster Handbook (E-G70).” Royal Yachting Association, 2018.](https://books.apple.com/us/book/rya-yachtmaster-handbook-e-g70/id1361646263) 
 
-helicopter strop
+This is the scenario that quietly invalidates a lot of the neater answers, including the life-sling. Once you're sending a second person down to water level, you're accepting a meaningful risk to them too — which is a strong argument for the boat-handling being good enough that this stays a last resort.
+
+For the worst cases there's also the helicopter strop, i.e. handing the recovery over to search and rescue — which is part of why the "call" step happens early rather than once you've run out of other ideas.
 
 ## If COB is still attached to the boat
+
+A different situation, and one that's easy to assume is the good outcome. If they're still clipped on, you haven't lost them — but they're now being dragged alongside a moving hull, which becomes dangerous quickly. So the priority inverts: there's no maneuver to choose here, the entire job is to stop the boat.
 
 Stop the boat asap
 
 - Heave to
 - Or go into the wind (at iron?)
 
+## Practising this
+
+One last thing, which is easy to skip past but changes how you use everything above:
+
 > “Don’t practice MOB recovery on a live crew. Too many things can go wrong. For a dummy, make a float that will be about as visible as a person in the water and is heavy enough it won’t be blown by the wind. A pair of half-filled one-gallon water jugs tied together works well and you can retrieve your homemade “Dunkin” with a boathook”
 >
 > - Excerpt From: [The American Sailing Association. “Coastal Cruising Made Easy.”](https://books.apple.com/us/book/coastal-cruising-made-easy/id1088937695) 
+
+Note the detail on the dummy: as visible as a person, and heavy enough not to blow downwind. A fender on a line is much easier to spot and drifts quite differently, so practising against one flatters your technique. The point of the drill is to rehearse the hard version.
 
 <!-- ##  Man overboard liquid color  -->
 
@@ -436,6 +542,8 @@ Stop the boat asap
 - [Is it safe to use a tether?](https://www.pbo.co.uk/seamanship/is-it-safe-to-use-a-tether-25125)
 
 ## Other Videos of MOB
+
+The videos above are mostly instructional — clean demonstrations in manageable conditions. These are the other half of the picture: real incidents and training footage, which are worth watching precisely because they show how much less tidy it looks when it actually happens.
 
 On YouTube - The Sailing Frenchman - [Man Overboard offshore: prepare for the worst, hope for the best - Ep110 - The Sailing Frenchman - 2:59](https://youtu.be/8NpzMnwR6VA?t=179) as part of Clipper's crew training.
 

--- a/categories/blog/2020-07-25-sailing-mob.md
+++ b/categories/blog/2020-07-25-sailing-mob.md
@@ -56,6 +56,10 @@ Between them, those two quotes set up the rest of this post. The maneuvers below
 
 To lower the barrier to entry for this post, here are a few quick explanations of some of the sailing terminology used.
 
+### MOB / COB / PIW
+
+These all refer to the same thing and you'll see them used interchangeably below, mostly following whichever the source I'm quoting used: **MOB** (man overboard), **COB** (crew overboard) and occasionally **PIW** (person in water). The RYA's more recent inclusive language guidance suggests alternatives like "person in water" for general use, while being explicit that *"man overboard"* stays as it is when actually shouted — it's a standardised command embedded in training, equipment and international protocols, and that's not something to be creative with mid-emergency.
+
 ### Point of sail
 
 Your point of sail is your angle to the wind, and it's the vocabulary every maneuver below is written in — "go onto a beam reach", "return on a close reach". So it's worth being comfortable with the diagram before the maneuvers will read as anything other than jargon.
@@ -136,22 +140,14 @@ The last two are easy to overlook when reading a diagram, but they're often what
 
 Before any of the maneuvers, there's a set of things that happen immediately, regardless of which one you then choose. The ASA packages them as a mnemonic:
 
-**“Y, P**, **T**, **S**, **C**”
+**“Y, T**, **P**, **S**, **C**”
 
 Excerpt From: [The American Sailing Association. “Bareboat Cruising Made Easy.”](https://books.apple.com/us/book/bareboat-cruising-made-easy/id1088940412). 
 
 The point of a mnemonic here is that this is the part you don't want to be improvising. These steps mostly cost seconds and buy you enormous amounts — a spotter keeping eyes on, flotation in the water, and someone else alerted — before the boat handling even starts.
 
 1. **Yell/Shout** “Man overboard”
-2. **Point** Nominate a spotter / pointer
-
-    > “Throughout the maneuver that follows, the spotter never takes his eyes off the COB, points toward him at all times, and communicates regularly with the helmsman, describing the COB’s location relative to the boat using both distance (e.g., “Three boat lengths”) and direction (e.g., “Dead astern”).”
-    > 
-    > - Excerpt From: [The American Sailing Association. “Sailing Made Easy.”](https://books.apple.com/us/book/sailing-made-easy/id1090161781). 
-
-    Note that this is a dedicated job for one person, who does nothing else for the whole maneuver. A head in the water is astonishingly hard to spot even in moderate seas, and once lost it's very hard to reacquire — hence the "never takes his eyes off" framing, and hence the Williamson turn further down existing specifically for the case where sight *has* been lost.
-
-3. **Throw** floating aids
+2. **Throw** floating aids
     1. Lifebelts
     2. Danbuoy
         1. Ideally 
@@ -162,9 +158,20 @@ The point of a mnemonic here is that this is the part you don't want to be impro
 
         The reasoning is that flotation blows downwind faster than a person floating low in the water does. Without a drogue, the thing you threw to mark the spot quietly stops marking the spot.
 
-4. **Call / Mayday** / Radio alert
-    1. MOB button on GPS
-    2. Call VHF Channel 16 to alert of the MOB situation
+3. **Point** Nominate a spotter / pointer
+
+    > “Throughout the maneuver that follows, the spotter never takes his eyes off the COB, points toward him at all times, and communicates regularly with the helmsman, describing the COB’s location relative to the boat using both distance (e.g., “Three boat lengths”) and direction (e.g., “Dead astern”).”
+    > 
+    > - Excerpt From: [The American Sailing Association. “Sailing Made Easy.”](https://books.apple.com/us/book/sailing-made-easy/id1090161781). 
+
+    Note that this is a dedicated job for one person, who does nothing else for the whole maneuver. A head in the water is astonishingly hard to spot even in moderate seas, and once lost it's very hard to reacquire — hence the "never takes his eyes off" framing, and hence the Williamson turn further down existing specifically for the case where sight *has* been lost.
+
+4. **Set** the MOB button on the GPS
+
+    This marks the position at the moment they went in, which is the number the Williamson turn and any search pattern are built around. It's also the step that's easiest to forget, because unlike the others nothing visibly happens when you do it.
+
+5. **Call / Mayday** / Radio alert
+    1. Call VHF Channel 16 to alert of the MOB situation
         1. “Pan-Pan, all stations” if not life threatening
         2. Otherwise “Mayday”
         3. Once MOB resolved, call to say all good
@@ -281,7 +288,7 @@ This is the one most people are taught first, and it's the most forgiving: every
 
 - Regardless of your point of sail go onto a beam reach
 - Furl the Genoa
-- Proceed to 3 to 6 boat length spending on wind speed and waves.
+- Proceed four to six boat lengths, depending on wind speed and waves
 
     > “A distance of four to six boat lengths (20 to 30 seconds) should be sufficient — the distance will be shorter in lighter winds and longer in higher winds. ”
     >
@@ -446,7 +453,9 @@ Good if you lose sight of the MOB, or in low visibility.
 >
 > - [“Man overboard rescue turn.” Wikipedia.](https://en.wikipedia.org/wiki/Man_overboard_rescue_turn#Williamson_turn)
 
-The elegance of it is that it puts you back on your exact reciprocal track — you retrace your own path rather than guessing at a position. Which is why it's a ship-handling technique originally: it works when the thing you're looking for is somewhere behind you and you can no longer see it.
+The elegance of it is that it puts you back on your exact reciprocal track — you retrace your own path rather than guessing at a position. That's why it works when you've lost sight of the person: you re-cross the line they're on regardless of exactly when they went in.
+
+The trade-off, and the reason it isn't the default, is that it's comparatively slow and initially takes you *further* from the scene. Where the casualty is in sight and the boat is manoeuvrable, a tighter single turn gets you back sooner. Worth noting too that this is ship-handling terminology — there are sibling maneuvers (the Anderson and Scharnow turns) that trade differently between speed and regaining track.
 
 [https://youtu.be/hXyY0BcaxbU](https://youtu.be/hXyY0BcaxbU)
 

--- a/categories/blog/2020-07-25-sailing-mob.md
+++ b/categories/blog/2020-07-25-sailing-mob.md
@@ -182,7 +182,7 @@ The point of a mnemonic here is that this is the part you don't want to be impro
 
 ## Common key parts of maneuvers
 
-In the section below we'll look at a few different maneuvers, but thought it would be useful to first highlight some common steps. Once you line the maneuvers up side by side, most of what looks like variation turns out to be different routes to the same final approach.
+In the section below we'll look at a few different maneuvers, but it's worth first highlighting some common steps. Once you line the maneuvers up side by side, most of what looks like variation turns out to be different routes to the same final approach.
 
 - **Turn your engine on**. If the engine fails, proceed to MOB under sail, otherwise furl in the sails.
 - If under sail can do *optional* **heave to**, to buy time to do “first response” steps described above.
@@ -353,8 +353,8 @@ Two conditions, both of which have to hold. This is the clearest example in the 
 - Head to wind
 - Jibe
 - Circle back to COB
-- If time furl the jib otherwise let it luff
-- Luff the main sail to stop the boat
+- If time, furl the jib; otherwise, let it luff
+- Luff the mainsail to stop the boat
 
 ![Quick Stop Diagram](/img/sailing-mob/asa-103-all-3-days-2018-30-638.jpg)
 


### PR DESCRIPTION
**Is your Pull Request request related to another issue in this repository ?**

No. Touches one file only — `categories/blog/2020-07-25-sailing-mob.md` — so it's independent of the layout/SEO work that landed via #30 and #33.

**Describe what the PR does**

Three passes over the sailing man-overboard post, in increasing order of significance.

The first is a plain readability edit: run-on intro prose split up, typos fixed, redundant bare-URL video and reference links deduped, a run-together quote separated, and a misnumbered list corrected. Citation and link formatting is now consistent throughout.

The second restructures how the post uses its sources. The post had accumulated a lot of material in the form of stacked quotes — in one case six consecutive blockquotes with no connecting prose — leaving the reader to work out why each one was there. Every source now follows point → expand → comment: a sentence stating the claim, the quote as the evidence, then what it means in practice or how it contrasts with the alternatives. This also surfaced the post's implicit thesis and made it explicit: neither the RYA nor the ASA prescribes a single correct maneuver, all the under-sail maneuvers converge on the same final approach (finish upwind, on a close reach), and the reason that particular target matters is that the error is self-correcting — misjudge it and you drift toward the person rather than away. The individual maneuvers then read as trade-offs against a shared goal instead of three unrelated recipes.

The third is a fact-check against current published RYA and ASA guidance, which turned up a real error. The ASA first-response mnemonic is **Y-T-P-S-C** (Yell, Throw, Point, Set, Call); the post had it as "Y, P, T, S, C" with P and T transposed, while an excerpt quoted further down in the same post spelled it correctly — so it contradicted itself. Relatedly, the numbered list beneath it only had four steps, because **S** (Set the MOB button on the GPS) had been folded in as a sub-bullet under "Call". A five-letter mnemonic over a four-step list is the kind of thing that quietly fails to stick, so S is now its own step, which also lets it connect to the Williamson turn later — that GPS mark is the position the search is built around. Two smaller corrections: the Figure of Eight bullet said "3 to 6 boat length" while the ASA excerpt directly beneath it says four to six, and the Williamson turn was presented with only its upside, so it now carries the trade-off that makes it a specific-case tool (it's comparatively slow and initially takes you further from the scene).

Also adds a short MOB / COB / PIW terminology note, since the post uses all three depending on which source is being quoted, and records that "man overboard" remains the standardised spoken command.

**State whether the PR is ready for review or whether it needs extra work**

Ready. Verified as correct against current guidance and left unchanged: the close-reach approach finishing upwind, the heaving-to description, the Figure of Eight being jibe-free at the cost of sailing away from the casualty, the Quick Stop being fastest but crew- and conditions-limited, and the Mayday vs Pan-Pan framing.

Two caveats on the fact-check. The quoted books are paywalled Apple Books editions, so verification was against the two bodies' public curriculum material and independent sailing sources rather than word-for-word against the 2018 editions. And the outbound network policy in the environment I was working in blocks `rya.org.uk`, `asa.com` and `pbo.co.uk`, so the post's external links could not be tested for rot — worth a pass in a browser, particularly as one RYA link is already archived via the Wayback Machine, which suggests it broke once before.

**Additional context**

The four review comments from the first round are addressed. Three were applied: the missing subject in "but thought it would be useful", punctuation on the "if time furl the jib" bullet, and "main sail" → "mainsail" for consistency with the other six uses.

The fourth — deleting step 6 of the Williamson turn list as redundant with step 5 — was deliberately not applied. The redundancy is real, but that list is a direct quotation from Wikipedia, so the repetition belongs to the source; silently dropping a numbered item would misrepresent the citation.

One open editorial question, left as the author's call rather than changed unilaterally: the prose mixes MOB (19 uses) and COB (15) roughly evenly, while the sources use MOB almost exclusively. The new terminology note defuses the confusion for the reader, but normalising throughout is a judgement about the post's voice.
